### PR TITLE
Fix problems caused by unstable data format of duoshuo

### DIFF
--- a/disqus.ejs
+++ b/disqus.ejs
@@ -7,62 +7,50 @@
 >
   <channel>
   <% for(var i = 0; i < threads.length; i++) {
-    var item = threads[i];
+    var thread = threads[i];
+    if (!thread.thread_key) continue;
     %>
     <item>
       <!-- title of article -->
-      <title><%= item.title %></title>
+      <title><%= thread.title %></title>
       <!-- absolute URI to article -->
-      <link><%= item.url %></link>
+      <link><%= thread.url %></link>
       <!-- body of the page or post; use cdata; html allowed (though will be formatted to DISQUS specs) -->
-      <content:encoded><![CDATA[<%= item.content %>]]></content:encoded>
+      <content:encoded><![CDATA[<%= thread.content %>]]></content:encoded>
       <!-- value used within disqus_identifier; usually internal identifier of article -->
-      <dsq:thread_identifier><%= item.thread_id %></dsq:thread_identifier>
+      <dsq:thread_identifier><%= thread.thread_key %></dsq:thread_identifier>
       <!-- creation date of thread (article), in GMT. Must be YYYY-MM-DD HH:MM:SS 24-hour format. -->
-      <wp:post_date_gmt><%= item.created_at %></wp:post_date_gmt>
+      <wp:post_date_gmt><%= thread.created_at %></wp:post_date_gmt>
       <!-- open/closed values are acceptable -->
       <wp:comment_status>open</wp:comment_status>
-    </item>
-  <% } %>
-  <% for(var i = 0; i < posts.length; i++) {
-    var item = posts[i];
-    if(!item.message || item.message.length < 3) {
-      item.message = item.message ? item.message + "..." : "nice!"
-    }
-    %>
-    <item>
-      <!-- title of article -->
-      <title><%= item.title %></title>
-      <!-- absolute URI to article -->
-      <link><%= item.url %></link>
-      <!-- body of the page or post; use cdata; html allowed (though will be formatted to DISQUS specs) -->
-      <content:encoded><![CDATA[<%= item.content %>]]></content:encoded>
-      <!-- value used within disqus_identifier; usually internal identifier of article -->
-      <dsq:thread_identifier><%= item.thread_id %></dsq:thread_identifier>
-      <!-- creation date of thread (article), in GMT. Must be YYYY-MM-DD HH:MM:SS 24-hour format. -->
-      <wp:post_date_gmt><%= item.created_at %></wp:post_date_gmt>
-      <!-- open/closed values are acceptable -->
-      <wp:comment_status>open</wp:comment_status>
+      <% for(var j = 0; j < posts.length; j++) {
+        var post = posts[j];
+        if (post.thread_key !== thread.thread_key) continue;
+        if(!post.message || post.message.length < 3) {
+          post.message = post.message ? post.message + "..." : "nice!"
+        }
+      %>
       <wp:comment>
         <!-- internal id of comment -->
-        <wp:comment_id><%= item.post_id %></wp:comment_id>
+        <wp:comment_id><%= post.post_key %></wp:comment_id>
         <!-- author display name -->
-        <wp:comment_author><%= item.author_name %></wp:comment_author>
+        <wp:comment_author><%= post.author_name %></wp:comment_author>
         <!-- author email address -->
-        <wp:comment_author_email><%= item.author_email || "null@null.com" %></wp:comment_author_email>
+        <wp:comment_author_email><%= post.author_email || "null@null.com" %></wp:comment_author_email>
         <!-- author url, optional -->
-        <wp:comment_author_url><%= item.author_url %></wp:comment_author_url>
+        <wp:comment_author_url><%= post.author_url %></wp:comment_author_url>
         <!-- author ip address -->
-        <wp:comment_author_IP><%= item.ip %></wp:comment_author_IP>
+        <wp:comment_author_IP><%= post.ip %></wp:comment_author_IP>
         <!-- comment datetime, in GMT. Must be YYYY-MM-DD HH:MM:SS 24-hour format. -->
-        <wp:comment_date_gmt><%= item.created_at %></wp:comment_date_gmt>
+        <wp:comment_date_gmt><%= post.created_at %></wp:comment_date_gmt>
         <!-- comment body; use cdata; html allowed (though will be formatted to DISQUS specs) -->
-        <wp:comment_content><![CDATA[<%= item.message %>]]></wp:comment_content>
+        <wp:comment_content><![CDATA[<%= post.message %>]]></wp:comment_content>
         <!-- is this comment approved? 0/1 -->
-        <wp:comment_approved><%= item.liked || 0 %></wp:comment_approved>
+        <wp:comment_approved>1</wp:comment_approved>
         <!-- parent id (match up with wp:comment_id) -->
-        <wp:comment_parent><%= item.parents || 0 %></wp:comment_parent>
+        <wp:comment_parent>0</wp:comment_parent>
       </wp:comment>
+      <% } %>
     </item>
   <% } %>
   </channel>

--- a/migrate.js
+++ b/migrate.js
@@ -71,7 +71,9 @@ threads:
   author_id: 0
 posts
   post_id: 1221878475854446600,
-  thread_id: 1221878475854446600,
+  post_key: "xxxxxxxxxxxxxxxxxxx",        // 在旧版本数据中更重要，在新版本数据中与 post_id 保持一致
+  thread_id: 1221878475854446600,         
+  thread_key: "xxxxx",
   message: "对浏览器兼容问题的解决么",
   site_id: 1111292,
   created_at: "2013-10-31T18:08:22+08:00",
@@ -83,8 +85,38 @@ posts
   author_email: "",
   author_name: "DINO",
   author_url: "http://t.qq.com/a904591031",
-  author_key: "0"
+  author_key: "0" | null
  */
+
+// 更新时间格式为 YYYY-MM-DD HH:MM:SS (GMT)
+function formatTime(datetimeString) {
+  var date = new Date(datetimeString);
+  var year = date.getUTCFullYear(),
+    month = date.getUTCMonth() + 1,
+    day = date.getUTCDate(),
+    hours = date.getUTCHours(),
+    minutes = date.getUTCMinutes(),
+    seconds = date.getUTCSeconds();
+  var arr = [month, day, hours, minutes, seconds].map(function(val) {
+    var str = val.toString();
+    while (str.length < 2) str = '0' + str;
+    return str;
+  });
+  return year + '-' + arr[0] + '-' + arr[1] + ' ' + arr.slice(2).join(':');
+}
+
+function updateData(dataList) {
+  return dataList.map(function(obj) {
+    var newObj = JSON.parse(JSON.stringify(obj));
+    newObj.created_at = formatTime(obj.created_at);
+    newObj.updated_at = formatTime(obj.updated_at);
+    return newObj;
+  });
+}
+
+duoshuoJSON.posts = updateData(duoshuoJSON.posts);
+duoshuoJSON.threads = updateData(duoshuoJSON.threads);
+
 var disqusXML = fs.readFileSync("./disqus.ejs").toString();
 var disqusCtt = ejs.render(disqusXML, duoshuoJSON);
 


### PR DESCRIPTION
我最近导出了多说的数据，但是直接使用 migrate.js 脚本无法迁移成功，做了如下更改后完成迁移：

- 使用 thread_key 和 post_key 替换原本的 thread_id 和 post_id
- 评论默认设定为 approved
- 不保留多说评论的 parents 关系（由于 post_id 数据存在大量问题，无法自动修复）
- 生成的 xml 中，将所有同一文章下的 `<wp:comment>` 生成在一个 `<item>` 中
- 按照 Disqus 数据要求更改日期的格式

参考：
- [Custom XML Import Format](https://help.disqus.com/customer/en/portal/articles/472150-custom-xml-import-format)